### PR TITLE
fixed bug in sqlite_timed_source component which tried to save the fi…

### DIFF
--- a/grc/sqlite_timed_source.xml
+++ b/grc/sqlite_timed_source.xml
@@ -13,7 +13,7 @@
   <param>
     <name>Filename</name>
     <key>filename</key>
-    <type>file_save</type>
+    <type>file_open</type>
   </param>
   <param>
     <name>Table Name</name>


### PR DESCRIPTION
…le instead of open it

Verified that the file_open type would cause the file open dialog to be used instead of the file save dialog.